### PR TITLE
v1.0.59

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "roku-test-automation",
-    "version": "1.0.58",
+    "version": "1.0.59",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -251,9 +251,9 @@
             }
         },
         "@types/http-proxy": {
-            "version": "1.17.4",
-            "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.4.tgz",
-            "integrity": "sha512-IrSHl2u6AWXduUaDLqYpt45tLVCtYv7o4Z0s1KghBCDgIIS9oW5K1H8mZG/A2CfeLdEa7rTd1ACOiHBc1EMT2Q==",
+            "version": "1.17.5",
+            "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.5.tgz",
+            "integrity": "sha512-GNkDE7bTv6Sf8JbV2GksknKOsk7OznNYHSdrtvPJXO0qJ9odZig6IZKUi5RFGi6d1bf6dgIAe4uXi3DBc7069Q==",
             "requires": {
                 "@types/node": "*"
             }
@@ -1312,9 +1312,9 @@
             }
         },
         "follow-redirects": {
-            "version": "1.13.1",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.1.tgz",
-            "integrity": "sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg=="
+            "version": "1.13.2",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.2.tgz",
+            "integrity": "sha512-6mPTgLxYm3r6Bkkg0vNM0HTjfGrOEtsfbhagQvbxDEsEkpNhw582upBaoRZylzen6krEmxXJgt9Ju6HiI4O7BA=="
         },
         "foreground-child": {
             "version": "1.5.6",
@@ -1524,9 +1524,9 @@
             }
         },
         "http-network-proxy": {
-            "version": "1.0.7",
-            "resolved": "/Users/bleighty/repositories/dev/http-network-proxy/http-network-proxy-1.0.7.tgz",
-            "integrity": "sha512-SBhxROkX9LvCBM/p/QhgJcnjnZ5wtcjLsnZP2wkmvp/j2aXqTvdF4nMxqwK2vvrd4LAfiwPzOJq+qI09kd39BQ==",
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/http-network-proxy/-/http-network-proxy-1.0.9.tgz",
+            "integrity": "sha512-lb4XNgLOmY9H4joBKS4IEA9oBv3tatTQCFvfWlE4Ow4ioMagLnSvUeCJpuEggQPq8UV6r8pM9l1Y3n3p0FDe/g==",
             "requires": {
                 "@types/express": "^4.17.6",
                 "express": "^4.17.1",
@@ -1540,14 +1540,14 @@
             },
             "dependencies": {
                 "fs-extra": {
-                    "version": "9.0.1",
-                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
-                    "integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
+                    "version": "9.1.0",
+                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+                    "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
                     "requires": {
                         "at-least-node": "^1.0.0",
                         "graceful-fs": "^4.2.0",
                         "jsonfile": "^6.0.1",
-                        "universalify": "^1.0.0"
+                        "universalify": "^2.0.0"
                     }
                 },
                 "jsonfile": {
@@ -1557,13 +1557,6 @@
                     "requires": {
                         "graceful-fs": "^4.1.6",
                         "universalify": "^2.0.0"
-                    },
-                    "dependencies": {
-                        "universalify": {
-                            "version": "2.0.0",
-                            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-                            "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
-                        }
                     }
                 },
                 "rimraf": {
@@ -1575,9 +1568,9 @@
                     }
                 },
                 "universalify": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
-                    "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug=="
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+                    "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
                 }
             }
         },

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
     "name": "roku-test-automation",
-    "version": "1.0.58",
+    "version": "1.0.59",
     "description": "Helps with automating functional tests",
     "main": "server/dist/index.js",
     "typings": "server/dist/index.d.ts",
@@ -29,7 +29,7 @@
         "express": "^4.17.1",
         "fs-extra": "^7.0.1",
         "get-stack-trace": "^2.0.3",
-        "http-network-proxy": "^1.0.7",
+        "http-network-proxy": "^1.0.9",
         "needle": "^2.3.2",
         "path": "^0.12.7",
         "portfinder": "^1.0.26",

--- a/server/rta-config.schema.json
+++ b/server/rta-config.schema.json
@@ -34,7 +34,12 @@
                     "type": "string"
                 },
                 "port": {
+                    "description": "What port the proxy will run on. If not provided will fine one itself",
                     "type": "number"
+                },
+                "serverDebugLogging": {
+                    "description": "Enable debug logging on the server side",
+                    "type": "boolean"
                 }
             },
             "type": "object"
@@ -56,6 +61,10 @@
                 },
                 "restoreRegistry": {
                     "description": "Before running any requests will pull the contents of the registry on the device and store it until ODC is shutdown.\nAt which point it will clear the registry completely and write back the stored registry values that were previously stored.",
+                    "type": "boolean"
+                },
+                "serverDebugLogging": {
+                    "description": "Enable debug logging on the server side",
                     "type": "boolean"
                 }
             },

--- a/server/src/test/include.ts
+++ b/server/src/test/include.ts
@@ -2,6 +2,11 @@ import { utils } from '../utils';
 import { proxy, odc } from '../';
 utils.setupEnvironmentFromConfigFile();
 
+process.on('unhandledRejection', (reason) => {
+	console.error(reason);
+	process.exit(1);
+});
+
 after(async function () {
 	await proxy.stop();
 	await odc.shutdown();

--- a/server/src/types/ConfigOptions.ts
+++ b/server/src/types/ConfigOptions.ts
@@ -55,6 +55,10 @@ export interface ECPConfigOptions {
 export interface OnDeviceComponentConfigOptions {
 	/** Device side log output level */
 	logLevel?: ODCLogLevels;
+
+	/** Enable debug logging on the server side */
+	serverDebugLogging?: boolean;
+
 	/**
 	 * Before running any requests will pull the contents of the registry on the device and store it until ODC is shutdown.
 	 * At which point it will clear the registry completely and write back the stored registry values that were previously stored.
@@ -63,7 +67,11 @@ export interface OnDeviceComponentConfigOptions {
 }
 
 export interface NetworkProxyOptions {
+	/** What port the proxy will run on. If not provided will fine one itself */
 	port?: number;
+
+	/** Enable debug logging on the server side */
+	serverDebugLogging?: boolean;
 
 	/** Useful for visually debugging issues. Use in the format like (http://127.0.0.1:8888). DOES NOT WORK WITH RELATIVE REDIRECTS IN CHARLES!!! */
 	forwardProxy?: string;


### PR DESCRIPTION
Better handle cases where we can't reset the registry when shutting down network proxy, add pause and resume methods to NetworkProxy. Add support for turning debug logging on or off with config in both NetworkProxy and OnDeviceComponent, update http-network-proxy to 1.0.9