### PR TITLE
v1.1.2 - Add disableTelnet and disableCallOriginationLine ODC config options to improve usage in RDB

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -34,7 +34,11 @@
 			"password": "${env:ROKU_PASSWORD}",
 			"internalConsoleOptions": "neverOpen",
 			"stopDebuggerOnAppExit": true,
-			"injectRaleTrackerTask": true
+			"injectRaleTrackerTask": true,
+			"injectRdbOnDeviceComponent": true,
+			"bsConst": {
+				"ENABLE_RTA": true
+			}
 		}, {
 			"type": "node",
 			"request": "launch",

--- a/device/components/RTA_OnDeviceComponentTask.brs
+++ b/device/components/RTA_OnDeviceComponentTask.brs
@@ -270,12 +270,9 @@ sub sendBackError(request as Object, message as String)
 end sub
 
 sub sendBackResponse(request as Object, response as Dynamic)
-	if isAA(response) then
-		if NOT isBoolean(response.success) then response.success = true
-		formattedResponse = formatJson(response)
-	else
-		formattedResponse = response
-	end if
+	if NOT isBoolean(response.success) then response.success = true
+	response["requestType"] = request.type
+	formattedResponse = formatJson(response)
 
 	callbackUrl = getCallbackUrl(request)
 	http = createObject("roUrlTransfer")
@@ -286,5 +283,5 @@ sub sendBackResponse(request as Object, response as Dynamic)
 	if NOT http.asyncPostFromString(formattedResponse) then
 		logError("Could not send callback")
 	end if
-	m.activeTransfers[http.GetIdentity().toStr()] = http
+	m.activeTransfers[http.getIdentity().toStr()] = http
 end sub

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "roku-test-automation",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
     "name": "roku-test-automation",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "description": "Helps with automating functional tests",
     "main": "server/dist/index.js",
     "typings": "server/dist/index.d.ts",

--- a/server/rta-config.schema.json
+++ b/server/rta-config.schema.json
@@ -47,6 +47,14 @@
         "OnDeviceComponent": {
             "additionalProperties": false,
             "properties": {
+                "disableCallOriginationLine": {
+                    "description": "We normally try to include the line that the actual ODC call originated from. When not used specifically for testing this isn't needed as much and has a small over head as we have to throw and exception to get the line",
+                    "type": "boolean"
+                },
+                "disableTelnet": {
+                    "description": "We normally pull the telnet logs if the request timed out. If the telnet connection is already in use then this just adds additional noise in the output",
+                    "type": "boolean"
+                },
                 "logLevel": {
                     "description": "Device side log output level",
                     "enum": [

--- a/server/src/OnDeviceComponent.spec.ts
+++ b/server/src/OnDeviceComponent.spec.ts
@@ -41,7 +41,27 @@ describe('OnDeviceComponent', function () {
 					expect(tree.subtype).to.be.string
 					expect(tree.ref).to.be.a('number');
 					expect(tree.parentRef).to.be.a('number');
-					expect(tree.children).to.be.array;
+					expect(tree.children).to.be.array();
+				}
+			});
+
+			it('should have exactly one global node included in the response', async () => {
+				let globalCount = 0;
+				expect(storeResult.rootTree).to.be.array();
+				for (const tree of storeResult.flatTree) {
+					expect(tree.global).to.be.oneOf([true, false]);
+					if (tree.global) {
+						globalCount++;
+					}
+				}
+
+				expect(globalCount).to.equal(1);
+			});
+
+			it('each tree should have a children array field', async () => {
+				expect(storeResult.rootTree).to.be.array();
+				for (const tree of storeResult.flatTree) {
+					expect(tree.children).to.be.array();
 				}
 			});
 		});
@@ -61,11 +81,9 @@ describe('OnDeviceComponent', function () {
 				const getResult = await odc.getNodeReferences({
 					indexes: indexes
 				});
-				expect(getResult.nodes).to.be.array;
 				expect(Object.keys(getResult.nodes).length).to.equal(indexes.length);
 				for (const index of indexes) {
 					const node = getResult.nodes[index];
-
 					expect(node).to.be.ok;
 					expect(node.id).to.equal(storeResult.flatTree[index].id);
 					expect(node.subtype).to.equal(storeResult.flatTree[index].subtype);
@@ -76,7 +94,6 @@ describe('OnDeviceComponent', function () {
 				const getResult = await odc.getNodeReferences({
 					indexes: []
 				});
-				expect(getResult.nodes).to.be.array;
 				expect(Object.keys(getResult.nodes).length).to.equal(storeResult.flatTree.length);
 				for (const index in storeResult.flatTree) {
 					const node = getResult.nodes[index];
@@ -85,6 +102,18 @@ describe('OnDeviceComponent', function () {
 					expect(node.id).to.equal(storeResult.flatTree[index].id);
 					expect(node.subtype).to.equal(storeResult.flatTree[index].subtype);
 				}
+			});
+
+			it('should include fields in the response', async () => {
+				const getResult = await odc.getNodeReferences({
+					indexes: [0]
+				});
+
+				const node = getResult.nodes[0];
+				expect(node.subtype).to.equal("MainScene");
+				expect(node.fields.visible.fieldType).to.equal("boolean");
+				expect(node.fields.visible.type).to.equal("roBoolean");
+				expect(node.fields.visible.value).to.equal(true);
 			});
 		});
 

--- a/server/src/OnDeviceComponent.ts
+++ b/server/src/OnDeviceComponent.ts
@@ -164,6 +164,15 @@ export class OnDeviceComponent {
 
 		const rootTree = [] as ODC.NodeTree[];
 		for (const tree of body.flatTree) {
+			// Add in global as we only return true for the single global node to minimize payload size so need to add false for all the other nodes
+			if (!tree.global) {
+				tree.global = false;
+			}
+
+			if (!tree.children) {
+				tree.children = [];
+			}
+
 			if (tree.parentRef === -1) {
 				rootTree.push(tree);
 				continue;
@@ -184,7 +193,17 @@ export class OnDeviceComponent {
 		const result = await this.sendRequest('getNodeReferences', args, options);
 		return result.body as {
 			nodes: {
-				[key: string]: ODC.NodeRepresentation
+				[key: string]: {
+					"id": string;
+					"subtype": string;
+					"fields": {
+						[key: string]: {
+							"fieldType": string;
+							"type": string;
+							"value": any;
+						}
+					}
+				}
 			}
 		} & ODC.ReturnTimeTaken;
 	}

--- a/server/src/types/ConfigOptions.ts
+++ b/server/src/types/ConfigOptions.ts
@@ -70,6 +70,12 @@ export interface OnDeviceComponentConfigOptions {
 	 * At which point it will clear the registry completely and write back the stored registry values that were previously stored.
 	 */
 	restoreRegistry?: boolean;
+
+	/** We normally pull the telnet logs if the request timed out. If the telnet connection is already in use then this just adds additional noise in the output */
+	disableTelnet?: boolean
+
+	/** We normally try to include the line that the actual ODC call originated from. When not used specifically for testing this isn't needed as much and has a small over head as we have to throw and exception to get the line */
+	disableCallOriginationLine?: boolean
 }
 
 export interface NetworkProxyOptions {

--- a/server/src/types/OnDeviceComponentRequest.ts
+++ b/server/src/types/OnDeviceComponentRequest.ts
@@ -204,7 +204,10 @@ export namespace ODC {
 		/** Same as ref but for the parent  */
 		parentRef: number;
 
-		children?: NodeTree[];
+		children: NodeTree[];
+
+		/** Let's us distinguish global node as it's own separate node from the Scene */
+		global: boolean;
 	}
 
 	export interface ReturnTimeTaken {


### PR DESCRIPTION
v1.1.2 - Add disableTelnet and disableCallOriginationLine ODC config options to improve usage in RDB, add requestType in our response back to server to help line up requests and responses, add RDB integration in testProject,  add log on initialization to help debugging if setup correctly, change return format for getNodeReferences to include `type` and `fieldType` fields for better integration with RDB, switch ODC.NodeTree.children from optional to required to simplify usage, add check for global node distinguishing