### PR TITLE
Feature/add send long keypress

### DIFF
--- a/client/src/ECP.spec.ts
+++ b/client/src/ECP.spec.ts
@@ -172,7 +172,9 @@ describe('ECP', function () {
 				assert.fail('sleep was not called');
 			}
 		});
+	});
 
+	describe('sendKeyDown', function () {
 		it('sends_key_down_event', async () => {
 			const postStub = sinon.stub(device, 'sendEcpPost').callsFake(((path: string, params?: object, body?: needle.BodyData) => {
 				expect(path).to.contain(ECP.Key.Play);
@@ -184,6 +186,21 @@ describe('ECP', function () {
 			expect(postStub.getCall(0).lastArg).to.include('keydown/Play');
 		});
 
+		it('sends_multiple_key_events', async () => {
+			const postStub = sinon.stub(device, 'sendEcpPost').callsFake(((path: string, params?: object, body?: needle.BodyData) => {
+				expect(path).to.contain(ECP.Key.Play);
+			}) as any);
+
+			await ecp.sendKeyDown(ECP.Key.Play, 0, { count: 3 });
+
+			expect(postStub.callCount).equals(3);
+			expect(postStub.getCall(0).lastArg).to.include('keydown/Play');
+			expect(postStub.getCall(1).lastArg).to.include('keydown/Play');
+			expect(postStub.getCall(2).lastArg).to.include('keydown/Play');
+		});
+	});
+
+	describe('sendKeyUp', function () {
 		it('sends_key_up_event', async () => {
 			const postStub = sinon.stub(device, 'sendEcpPost').callsFake(((path: string, params?: object, body?: needle.BodyData) => {
 				expect(path).to.contain(ECP.Key.Play);
@@ -194,7 +211,9 @@ describe('ECP', function () {
 			expect(postStub.callCount).equals(1);
 			expect(postStub.getCall(0).lastArg).to.include('keyup/Play');
 		});
+	});
 
+	describe('sendKeyPressAndHold', function () {
 		it('sends_long_key_press', async () => {
 			const postStub = sinon.stub(device, 'sendEcpPost').callsFake(((path: string, params?: object, body?: needle.BodyData) => {
 				expect(path).to.contain(ECP.Key.Play);
@@ -210,20 +229,9 @@ describe('ECP', function () {
 			expect(postStub.getCall(0).lastArg).to.include('keydown/Play');
 			expect(postStub.getCall(1).lastArg).to.include('keyup/Play');
 		});
+	});
 
-		it('sends_multiple_key_events', async () => {
-			const postStub = sinon.stub(device, 'sendEcpPost').callsFake(((path: string, params?: object, body?: needle.BodyData) => {
-				expect(path).to.contain(ECP.Key.Play);
-			}) as any);
-
-			await ecp.sendKeyDown(ECP.Key.Play, 0, { count: 3 });
-
-			expect(postStub.callCount).equals(3);
-			expect(postStub.getCall(0).lastArg).to.include('keydown/Play');
-			expect(postStub.getCall(1).lastArg).to.include('keydown/Play');
-			expect(postStub.getCall(2).lastArg).to.include('keydown/Play');
-		});
-
+	describe('sendKeyEvent', function () {
 		it('sends_regular_key_press_when_press_and_hold_has_no_duration', async () => {
 			const postStub = sinon.stub(device, 'sendEcpPost').callsFake(((path: string, params?: object, body?: needle.BodyData) => {
 				expect(path).to.contain(ECP.Key.Play);

--- a/client/src/ECP.spec.ts
+++ b/client/src/ECP.spec.ts
@@ -172,6 +172,70 @@ describe('ECP', function () {
 				assert.fail('sleep was not called');
 			}
 		});
+
+		it('sends_key_down_event', async () => {
+			const postStub = sinon.stub(device, 'sendEcpPost').callsFake(((path: string, params?: object, body?: needle.BodyData) => {
+				expect(path).to.contain(ECP.Key.Play);
+			}) as any);
+
+			await ecp.sendKeyDown(ECP.Key.Play);
+
+			expect(postStub.callCount).equals(1);
+			expect(postStub.getCall(0).lastArg).to.include('keydown/Play');
+		});
+
+		it('sends_key_up_event', async () => {
+			const postStub = sinon.stub(device, 'sendEcpPost').callsFake(((path: string, params?: object, body?: needle.BodyData) => {
+				expect(path).to.contain(ECP.Key.Play);
+			}) as any);
+
+			await ecp.sendKeyUp(ECP.Key.Play);
+
+			expect(postStub.callCount).equals(1);
+			expect(postStub.getCall(0).lastArg).to.include('keyup/Play');
+		});
+
+		it('sends_long_key_press', async () => {
+			const postStub = sinon.stub(device, 'sendEcpPost').callsFake(((path: string, params?: object, body?: needle.BodyData) => {
+				expect(path).to.contain(ECP.Key.Play);
+			}) as any);
+
+			sinon.stub(ecpUtils, 'sleep').callsFake(((milliseconds: number) => {
+				expect(milliseconds).to.greaterThan(0);
+			}) as any);
+
+			await ecp.sendKeyPressAndHold(ECP.Key.Play, 500);
+
+			expect(postStub.callCount).equals(2);
+			expect(postStub.getCall(0).lastArg).to.include('keydown/Play');
+			expect(postStub.getCall(1).lastArg).to.include('keyup/Play');
+		});
+
+		it('sends_multiple_key_events', async () => {
+			const postStub = sinon.stub(device, 'sendEcpPost').callsFake(((path: string, params?: object, body?: needle.BodyData) => {
+				expect(path).to.contain(ECP.Key.Play);
+			}) as any);
+
+			await ecp.sendKeyDown(ECP.Key.Play, 0, { count: 3 });
+
+			expect(postStub.callCount).equals(3);
+			expect(postStub.getCall(0).lastArg).to.include('keydown/Play');
+			expect(postStub.getCall(1).lastArg).to.include('keydown/Play');
+			expect(postStub.getCall(2).lastArg).to.include('keydown/Play');
+		});
+
+		it('sends_regular_key_press_when_press_and_hold_has_no_duration', async () => {
+			const postStub = sinon.stub(device, 'sendEcpPost').callsFake(((path: string, params?: object, body?: needle.BodyData) => {
+				expect(path).to.contain(ECP.Key.Play);
+			}) as any);
+
+			await ecp.sendKeyEvent(ECP.Key.Play, 0);
+			await ecp.sendKeyEvent(ECP.Key.Play, { keydown: true, keyup: true, duration: 0 });
+
+			expect(postStub.callCount).equals(2);
+			expect(postStub.getCall(0).lastArg).to.include('keypress/Play');
+			expect(postStub.getCall(1).lastArg).to.include('keypress/Play');
+		});
 	});
 
 	describe('getActiveApp', function () {


### PR DESCRIPTION
 from review feedback: add api functions for press and hold, keydown, and keyup

    Noted that requested API were similar to each other and different enough
    from original sendKeypress to merit refactor and creation of
    sendKeyEvent. This included small differences like input parameter
    normalization and larger differences like different ECP commands to
    post. Also felt that the automatic creation of RASP commands was awkward
    for unsupported keydown/keyup. Change includes a new super-type for key
    events.

    Added sendKeyPressAndHold, sendKeyDown, and sendKeyUp.
    Added unit tests for each new API function.
    Improved code comments for keypressDuration (ECP config option).

original commit...

    In ECP.ts, added duration field to SendKeypressOptions, which when used triggers a
    three call chain in ECP.sendKeypress to simulate a long press. This is a
    keydown followed by a sleep of duration milliseconds followed by a
    keyup.

    Also added ECP.sendLongKeypress function as a convenience. This
    function ensures that the duration option is set when calling
    ECP.sendKeypress. The duration is determined by order of precedence:
    1) value present in the function parameter, 2) default value from config
       (added to ConfigOptions.ts), 3) 500ms (approximates common threshold
    value from other frameworks like Android). Added a unit test in
    ECP.spec.ts.