### PR TITLE
Add device health checks to on-device test suites

### DIFF
--- a/src/NetworkProxy.device.spec.ts
+++ b/src/NetworkProxy.device.spec.ts
@@ -7,7 +7,7 @@ import * as express from 'express';
 
 import { utils } from './utils';
 import { ecp, odc, device, proxy } from '.';
-import { setupTestEnvironment, ensureDeviceIsReady } from './test/testHelpers.spec';
+import { setupTestEnvironment, ensureDeviceIsReady, ensureDeviceIsStillResponsive } from './test/testHelpers.spec';
 
 describe('NetworkProxy', function () {
 	let testServer: http.Server;
@@ -50,6 +50,13 @@ describe('NetworkProxy', function () {
 		await Promise.all([promise, proxy.start(proxyPort)]);
 	});
 
+
+	beforeEach(async function () {
+		//make sure the device is still reachable before running the next test, so a wedged device fails
+		//here with a clear message rather than midway through a test
+		this.timeout(120_000);
+		await ensureDeviceIsStillResponsive();
+	});
 
 	after(async () => {
 		await proxy.stop();

--- a/src/NetworkProxy.device.spec.ts
+++ b/src/NetworkProxy.device.spec.ts
@@ -7,7 +7,7 @@ import * as express from 'express';
 
 import { utils } from './utils';
 import { ecp, odc, device, proxy } from '.';
-import { setupTestEnvironment } from './test/testHelpers.spec';
+import { setupTestEnvironment, ensureDeviceIsReady } from './test/testHelpers.spec';
 
 describe('NetworkProxy', function () {
 	let testServer: http.Server;
@@ -16,8 +16,11 @@ describe('NetworkProxy', function () {
 	let proxyPort: number;
 
 	before(async function () {
-		this.timeout(120_000);
+		this.timeout(240_000);
 		setupTestEnvironment();
+		//make sure the device is actually reachable and responsive, and back at the home screen, before
+		//we deploy. Otherwise a device that's still booting fails the whole suite in `before`.
+		await ensureDeviceIsReady();
 		await device.deploy({
 			rootDir: 'testProject',
 			preventMultipleDeployments: true

--- a/src/OnDeviceComponent.device.spec.ts
+++ b/src/OnDeviceComponent.device.spec.ts
@@ -9,7 +9,7 @@ import * as assert from 'assert';
 import { utils } from './utils';
 import type * as ODC from './types/OnDeviceComponent';
 import { ecp, odc, device } from '.';
-import { setupTestEnvironment, ensureDeviceIsReady } from './test/testHelpers.spec';
+import { setupTestEnvironment, ensureDeviceIsReady, ensureDeviceIsStillResponsive } from './test/testHelpers.spec';
 
 // Used to unwrap promise return types to get the true value
 type Unwrap<T> = T extends Promise<infer U> ? U : T extends (...args: any) => Promise<infer U> ? U : T extends (...args: any) => infer U ? U : T;
@@ -25,6 +25,13 @@ describe('OnDeviceComponent', function () {
 			rootDir: 'testProject',
 			preventMultipleDeployments: true
 		});
+	});
+
+	beforeEach(async function () {
+		//make sure the device is still reachable before running the next test, so a wedged device fails
+		//here with a clear message rather than midway through a test
+		this.timeout(120_000);
+		await ensureDeviceIsStillResponsive();
 	});
 
 	after(async () => {

--- a/src/OnDeviceComponent.device.spec.ts
+++ b/src/OnDeviceComponent.device.spec.ts
@@ -9,15 +9,18 @@ import * as assert from 'assert';
 import { utils } from './utils';
 import type * as ODC from './types/OnDeviceComponent';
 import { ecp, odc, device } from '.';
-import { setupTestEnvironment } from './test/testHelpers.spec';
+import { setupTestEnvironment, ensureDeviceIsReady } from './test/testHelpers.spec';
 
 // Used to unwrap promise return types to get the true value
 type Unwrap<T> = T extends Promise<infer U> ? U : T extends (...args: any) => Promise<infer U> ? U : T extends (...args: any) => infer U ? U : T;
 
 describe('OnDeviceComponent', function () {
 	before(async function () {
-		this.timeout(120_000);
+		this.timeout(240_000);
 		setupTestEnvironment();
+		//make sure the device is actually reachable and responsive, and back at the home screen, before
+		//we deploy. Otherwise a device that's still booting fails the whole suite in `before`.
+		await ensureDeviceIsReady();
 		await device.deploy({
 			rootDir: 'testProject',
 			preventMultipleDeployments: true

--- a/src/RokuDevice.device.spec.ts
+++ b/src/RokuDevice.device.spec.ts
@@ -7,13 +7,16 @@ const expect = chai.expect;
 import * as querystring from 'querystring';
 import { rokuDeploy } from 'roku-deploy';
 import { ecp, device } from './';
-import { setupTestEnvironment } from './test/testHelpers.spec';
+import { setupTestEnvironment, ensureDeviceIsReady } from './test/testHelpers.spec';
 
 describe('RokuDevice', function () {
 	before(async function () {
-		//launching the channel and waiting for it to become active takes well over the default 10s timeout
-		this.timeout(120_000);
+		//waiting for the device to be online plus launching the channel takes well over the default 10s timeout
+		this.timeout(240_000);
 		setupTestEnvironment();
+		//make sure the device is actually reachable and responsive, and back at the home screen, before
+		//we launch anything. Otherwise a device that's still booting fails the whole suite in `before`.
+		await ensureDeviceIsReady();
 		await ecp.sendLaunchChannel();
 	});
 

--- a/src/RokuDevice.device.spec.ts
+++ b/src/RokuDevice.device.spec.ts
@@ -7,7 +7,7 @@ const expect = chai.expect;
 import * as querystring from 'querystring';
 import { rokuDeploy } from 'roku-deploy';
 import { ecp, device } from './';
-import { setupTestEnvironment, ensureDeviceIsReady } from './test/testHelpers.spec';
+import { setupTestEnvironment, ensureDeviceIsReady, ensureDeviceIsStillResponsive } from './test/testHelpers.spec';
 
 describe('RokuDevice', function () {
 	before(async function () {
@@ -18,6 +18,13 @@ describe('RokuDevice', function () {
 		//we launch anything. Otherwise a device that's still booting fails the whole suite in `before`.
 		await ensureDeviceIsReady();
 		await ecp.sendLaunchChannel();
+	});
+
+	beforeEach(async function () {
+		//make sure the device is still reachable before running the next test, so a wedged device fails
+		//here with a clear message rather than midway through a test
+		this.timeout(120_000);
+		await ensureDeviceIsStillResponsive();
 	});
 
 	afterEach(() => {

--- a/src/test/testHelpers.spec.ts
+++ b/src/test/testHelpers.spec.ts
@@ -7,7 +7,6 @@ import * as dotenv from 'dotenv';
 
 import { utils } from '../utils';
 import { RokuDevice } from '../RokuDevice';
-import { device } from '../index';
 
 const repoRootDir = path.resolve(__dirname, '../../');
 
@@ -55,6 +54,20 @@ export function setupTestEnvironment() {
 }
 
 /**
+ * A RokuDevice used only by the device-health helpers below. Deliberately constructed here rather
+ * than imported from `../index`: importing the barrel pulls the whole library (OnDeviceComponent,
+ * NetworkProxy, etc) into the unit test run, which drags all of it into the nyc coverage report even
+ * though the unit tests don't exercise it. Created lazily so it reads config after setupTestEnvironment.
+ */
+let healthCheckDevice: RokuDevice | undefined;
+function getHealthCheckDevice() {
+	if (!healthCheckDevice) {
+		healthCheckDevice = new RokuDevice();
+	}
+	return healthCheckDevice;
+}
+
+/**
  * Wait for the device to be reachable and responsive by polling both ECP (device-info) and the
  * installer web server (the same `plugin_install` endpoint sideload/publish use) until both respond.
  *
@@ -67,8 +80,9 @@ export function setupTestEnvironment() {
 export async function waitForDeviceOnline(timeoutMs = 120_000, intervalMs = 3000, graceMs = 0): Promise<void> {
 	const startTime = Date.now();
 	const deadline = startTime + timeoutMs;
-	const rokuDeployDevice = device.getRokuDeployDevice();
-	const password = device.getCurrentDeviceConfig().password;
+	const healthDevice = getHealthCheckDevice();
+	const rokuDeployDevice = healthDevice.getRokuDeployDevice();
+	const password = healthDevice.getCurrentDeviceConfig().password;
 
 	if (graceMs > 0) {
 		await utils.sleep(graceMs);
@@ -107,9 +121,10 @@ export async function waitForDeviceOnline(timeoutMs = 120_000, intervalMs = 3000
  * a known state instead of whatever the previous test left on screen.
  */
 export async function pressHomeButton(): Promise<void> {
-	await device.sendKeyPress('Home');
+	const healthDevice = getHealthCheckDevice();
+	await healthDevice.sendKeyPress('Home');
 	await utils.sleep(100);
-	await device.sendKeyPress('Home');
+	await healthDevice.sendKeyPress('Home');
 	await utils.sleep(100);
 }
 

--- a/src/test/testHelpers.spec.ts
+++ b/src/test/testHelpers.spec.ts
@@ -114,12 +114,26 @@ export async function pressHomeButton(): Promise<void> {
 }
 
 /**
- * Standard per-test device health gate: make sure the device is actually reachable and responsive,
- * then return it to the home screen. Call this from a `beforeEach` in device suites.
+ * Suite-level device health gate: make sure the device is actually reachable and responsive, then
+ * return it to the home screen so the suite starts from a known state instead of whatever the
+ * previous suite left running. Call this from a `before` hook, ahead of any deploy/launch.
  */
 export async function ensureDeviceIsReady(): Promise<void> {
 	await waitForDeviceOnline(90_000, 2000, 0);
 	await pressHomeButton();
+}
+
+/**
+ * Per-test device health gate: make sure the device is still reachable and responsive before the next
+ * test runs, so a device that's wedged or still coming back online fails here with a clear message
+ * instead of surfacing as a confusing failure midway through the test itself.
+ *
+ * Deliberately does NOT press Home the way the suite-level gate does. Suites that deploy once in
+ * `before` and then drive the channel over the ODC socket would have the channel exited out from
+ * under them by a per-test Home press.
+ */
+export async function ensureDeviceIsStillResponsive(): Promise<void> {
+	await waitForDeviceOnline(90_000, 2000, 0);
 }
 
 /**

--- a/src/test/testHelpers.spec.ts
+++ b/src/test/testHelpers.spec.ts
@@ -1,4 +1,5 @@
 import * as fsExtra from 'fs-extra';
+import { rokuDeploy } from 'roku-deploy';
 import type { EcpResponse } from '../RokuDevice';
 import { parseEcpResponse } from '../EcpXml';
 import * as path from 'path';
@@ -6,6 +7,7 @@ import * as dotenv from 'dotenv';
 
 import { utils } from '../utils';
 import { RokuDevice } from '../RokuDevice';
+import { device } from '../index';
 
 const repoRootDir = path.resolve(__dirname, '../../');
 
@@ -50,6 +52,74 @@ export function setupTestEnvironment() {
 	utils.setupEnvironmentFromConfig(config);
 
 	return config;
+}
+
+/**
+ * Wait for the device to be reachable and responsive by polling both ECP (device-info) and the
+ * installer web server (the same `plugin_install` endpoint sideload/publish use) until both respond.
+ *
+ * ECP alone isn't enough: it can come back before the installer server has finished settling, which
+ * shows up as flaky sideload failures even though an ECP check had just reported the device online.
+ *
+ * @param graceMs how long to wait before the first poll. Use a non-zero value after issuing something
+ *   that reboots the device, so we don't immediately see the still-alive pre-reboot device.
+ */
+export async function waitForDeviceOnline(timeoutMs = 120_000, intervalMs = 3000, graceMs = 0): Promise<void> {
+	const startTime = Date.now();
+	const deadline = startTime + timeoutMs;
+	const rokuDeployDevice = device.getRokuDeployDevice();
+	const password = device.getCurrentDeviceConfig().password;
+
+	if (graceMs > 0) {
+		await utils.sleep(graceMs);
+	}
+
+	let lastError: Error | undefined;
+	let count = 0;
+	while (Date.now() < deadline) {
+		if (count++ > 0) {
+			console.log(`[device-health] waiting for device to come online (${Date.now() - startTime}ms elapsed)`);
+		}
+		try {
+			//ensure the ECP webserver is responsive
+			await rokuDeploy.getDeviceInfo({ device: rokuDeployDevice, timeout: intervalMs });
+			//ensure the plugin_install webserver is responsive
+			await rokuDeploy.listSideloadedPlugins({ device: rokuDeployDevice, password: password, timeout: intervalMs });
+
+			//some devices are not fully ready to speak yet, so if this was the result of a long wait,
+			//wait a little bit longer
+			if (count > 1) {
+				console.log('[device-health] device is online, waiting a few more seconds to ensure it is fully ready...');
+				await utils.sleep(5_000);
+				console.log(`[device-health] device is online after ${Date.now() - startTime}ms`);
+			}
+			return;
+		} catch (e) {
+			lastError = e as Error;
+			await utils.sleep(intervalMs);
+		}
+	}
+	throw new Error(`Device did not come online within ${timeoutMs}ms. Last error: ${lastError?.message}`);
+}
+
+/**
+ * Send a couple of Home presses to clear any foreground app/screensaver, so the next test starts from
+ * a known state instead of whatever the previous test left on screen.
+ */
+export async function pressHomeButton(): Promise<void> {
+	await device.sendKeyPress('Home');
+	await utils.sleep(100);
+	await device.sendKeyPress('Home');
+	await utils.sleep(100);
+}
+
+/**
+ * Standard per-test device health gate: make sure the device is actually reachable and responsive,
+ * then return it to the home screen. Call this from a `beforeEach` in device suites.
+ */
+export async function ensureDeviceIsReady(): Promise<void> {
+	await waitForDeviceOnline(90_000, 2000, 0);
+	await pressHomeButton();
 }
 
 /**


### PR DESCRIPTION
The on-device CI run failed with `EHOSTUNREACH` in all three suites' `before` hooks — they went straight at the device without first checking it was up. Borrowing the approach from roku-deploy v4, device suites now wait for the device to be online before each suite and before each test.

- `waitForDeviceOnline` polls both ECP and the `plugin_install` web server. ECP alone isn't enough — it comes back before the installer server has settled, which shows up as flaky sideloads.
- `before` in each suite waits for the device and presses Home, ahead of any deploy/launch.
- `beforeEach` in each suite re-checks that the device is still responsive, so a wedged device fails with a clear message instead of surfacing midway through a test.
- Suite `before` timeouts raised from 120s to 240s to cover the wait.

The Home presses are suite-level only, unlike roku-deploy which also does them per-test. RTA's suites deploy once in `before` and then drive that channel over the ODC socket for the rest of the suite, so a per-test Home press would exit the channel out from under them.

Verified with `npm test` (62 passing) and `npm run lint`; the device suite itself runs on the self-hosted runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)