### PR TITLE
Add `waitForDeviceOnline` method to `RokuDevice` class

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@
     - [`deleteRegistrySections`](#deleteregistrysections)
     - [`deleteEntireRegistry`](#deleteentireregistry)
   - [`RokuDevice`](#rokudevice)
+    - [`waitForDeviceOnline`](#waitfordeviceonline)
   - [`NetworkProxy`](#networkproxy)
   - [`utils`](#utils)
     - [`setupEnvironmentFromConfigFile`](#setupenvironmentfromconfigfile)
@@ -737,6 +738,23 @@ Allows for disabling the screen saver in the application. While the screen saver
 ### `RokuDevice`
 
 Serves as the middle man for ECP requests and provides access to some of the capabilities provided by the Roku's built in web server. Currently creates and retrieves a screenshot as well as provides a helper for deploying.
+
+#### `waitForDeviceOnline`
+
+> waitForDeviceOnline(timeoutMs: number = 120000, intervalMs: number = 3000, graceMs: number = 0): Promise\<void>
+
+Waits for the device to be reachable and responsive before continuing. It polls both the ECP web server (`device-info`) and the installer web server (the same `plugin_install` endpoint sideload/publish use), since ECP can come back online before the installer server has finished settling. This makes it a useful health gate before deploying or launching, especially after a reboot.
+
+- `timeoutMs` how long to keep polling before giving up
+- `intervalMs` delay between poll attempts (also used as the per-request timeout)
+- `graceMs` how long to wait before the first poll. Use a non-zero value after issuing something that reboots the device, so we don't immediately see the still-alive pre-reboot device.
+
+```ts
+import { device } from 'roku-test-automation';
+
+// wait up to 90s, polling every 2s, after a 5s grace period (e.g. following a reboot)
+await device.waitForDeviceOnline(90_000, 2000, 5_000);
+```
 
 ---
 

--- a/src/RokuDevice.spec.ts
+++ b/src/RokuDevice.spec.ts
@@ -1,8 +1,22 @@
 import * as chai from 'chai';
 const expect = chai.expect;
+import * as sinonImport from 'sinon';
+const sinon = sinonImport.createSandbox();
+import { rokuDeploy } from 'roku-deploy';
 
 import { RokuDevice } from './RokuDevice';
+import { utils } from './utils';
 import type { ConfigOptions } from './types/ConfigOptions';
+
+/** Await a promise that's expected to reject, and return the error it rejected with */
+async function getRejection(promise: Promise<unknown>): Promise<Error> {
+	try {
+		await promise;
+	} catch (e) {
+		return e as Error;
+	}
+	throw new Error('Expected promise to reject, but it resolved');
+}
 
 describe('RokuDevice', function () {
 	let originalRceTokenEnvironmentVariable: string | undefined;
@@ -13,6 +27,7 @@ describe('RokuDevice', function () {
 	});
 
 	afterEach(() => {
+		sinon.restore();
 		if (originalRceTokenEnvironmentVariable === undefined) {
 			delete process.env.ROKU_RCE_TOKEN;
 		} else {
@@ -64,6 +79,114 @@ describe('RokuDevice', function () {
 				}
 			});
 			expect(device.getRokuDeployDevice()).to.eql({ id: 1, rceToken: undefined });
+		});
+	});
+
+	describe('waitForDeviceOnline', () => {
+		let device: RokuDevice;
+		let getDeviceInfoStub: sinonImport.SinonStub;
+		let listSideloadedPluginsStub: sinonImport.SinonStub;
+		let sleepStub: sinonImport.SinonStub;
+		/** every duration passed to `utils.sleep`, in call order */
+		let sleeps: number[];
+
+		beforeEach(() => {
+			device = new RokuDevice({
+				RokuDevice: {
+					devices: [{ host: '1.1.1.1', password: 'password' }]
+				}
+			});
+			getDeviceInfoStub = sinon.stub(rokuDeploy, 'getDeviceInfo').resolves({} as any);
+			listSideloadedPluginsStub = sinon.stub(rokuDeploy, 'listSideloadedPlugins').resolves([] as any);
+			sleeps = [];
+			//don't actually sleep, but record what we were asked to sleep for
+			sleepStub = sinon.stub(utils, 'sleep').callsFake(((milliseconds: number) => {
+				sleeps.push(milliseconds);
+				return Promise.resolve();
+			}) as any);
+			//the retry path logs progress, which we don't want cluttering test output
+			sinon.stub(console, 'log');
+		});
+
+		it('resolves without sleeping when the device answers on the first attempt', async () => {
+			await device.waitForDeviceOnline();
+
+			expect(getDeviceInfoStub.callCount).to.equal(1);
+			expect(listSideloadedPluginsStub.callCount).to.equal(1);
+			//no grace wait, no retry wait, and no post-success settle wait
+			expect(sleeps).to.eql([]);
+		});
+
+		it('passes the device config, password, and interval as the request timeout', async () => {
+			await device.waitForDeviceOnline(120_000, 4000);
+
+			expect(getDeviceInfoStub.getCall(0).args[0]).to.eql({
+				device: { host: '1.1.1.1' },
+				timeout: 4000
+			});
+			expect(listSideloadedPluginsStub.getCall(0).args[0]).to.eql({
+				device: { host: '1.1.1.1' },
+				password: 'password',
+				timeout: 4000
+			});
+		});
+
+		it('waits the grace period before the first poll', async () => {
+			await device.waitForDeviceOnline(120_000, 3000, 7000);
+
+			expect(sleeps).to.eql([7000]);
+			//the grace sleep must happen before we ever ask the device anything
+			expect(sleepStub.calledBefore(getDeviceInfoStub)).to.be.true;
+		});
+
+		it('skips the grace sleep when graceMs is 0', async () => {
+			await device.waitForDeviceOnline(120_000, 3000, 0);
+
+			expect(sleeps).to.eql([]);
+		});
+
+		it('retries until the device answers, then waits an extra settle period', async () => {
+			getDeviceInfoStub.onCall(0).rejects(new Error('ECP down'));
+			getDeviceInfoStub.onCall(1).rejects(new Error('ECP down'));
+
+			await device.waitForDeviceOnline(120_000, 3000);
+
+			expect(getDeviceInfoStub.callCount).to.equal(3);
+			//two interval sleeps for the two failures, then the 5s settle sleep on success
+			expect(sleeps).to.eql([3000, 3000, 5000]);
+		});
+
+		it('retries when ECP is up but the installer web server is not', async () => {
+			listSideloadedPluginsStub.onCall(0).rejects(new Error('plugin_install down'));
+
+			await device.waitForDeviceOnline(120_000, 3000);
+
+			expect(listSideloadedPluginsStub.callCount).to.equal(2);
+			expect(sleeps).to.eql([3000, 5000]);
+		});
+
+		it('throws with the last error message when the device never comes online', async () => {
+			getDeviceInfoStub.rejects(new Error('connect ETIMEDOUT'));
+			//sleep is stubbed out, so advance the clock ourselves to let the deadline actually expire
+			let now = Date.now();
+			sinon.stub(Date, 'now').callsFake(() => now);
+			sleepStub.callsFake(((milliseconds: number) => {
+				sleeps.push(milliseconds);
+				now += milliseconds;
+				return Promise.resolve();
+			}) as any);
+
+			const error = await getRejection(device.waitForDeviceOnline(10_000, 3000));
+			expect(error.message).to.equal('Device did not come online within 10000ms. Last error: connect ETIMEDOUT');
+			//10s deadline / 3s interval
+			expect(getDeviceInfoStub.callCount).to.equal(4);
+		});
+
+		it('throws without polling when the timeout has already elapsed', async () => {
+			const error = await getRejection(device.waitForDeviceOnline(0));
+			expect(error.message).to.equal('Device did not come online within 0ms. Last error: undefined');
+
+			expect(getDeviceInfoStub.callCount).to.equal(0);
 		});
 	});
 });

--- a/src/RokuDevice.ts
+++ b/src/RokuDevice.ts
@@ -166,6 +166,56 @@ export class RokuDevice {
 		return this.sendKeyEventToRokuDeploy('keyUp', key, options);
 	}
 
+	/**
+	 * Wait for the device to be reachable and responsive by polling both ECP (device-info) and the
+	 * installer web server (the same `plugin_install` endpoint sideload/publish use) until both respond.
+	 *
+	 * ECP alone isn't enough: it can come back before the installer server has finished settling, which
+	 * shows up as flaky sideload failures even though an ECP check had just reported the device online.
+	 *
+	 * @param timeoutMs how long to keep polling before giving up
+	 * @param intervalMs delay between poll attempts (also used as the per-request timeout)
+	 * @param graceMs how long to wait before the first poll. Use a non-zero value after issuing something
+	 *   that reboots the device, so we don't immediately see the still-alive pre-reboot device.
+	 */
+	public async waitForDeviceOnline(timeoutMs = 120_000, intervalMs = 3000, graceMs = 0): Promise<void> {
+		const startTime = Date.now();
+		const deadline = startTime + timeoutMs;
+		const rokuDeployDevice = this.getRokuDeployDevice();
+		const password = this.getCurrentDeviceConfig().password;
+
+		if (graceMs > 0) {
+			await utils.sleep(graceMs);
+		}
+
+		let lastError: Error | undefined;
+		let count = 0;
+		while (Date.now() < deadline) {
+			if (count++ > 0) {
+				console.log(`[device-health] waiting for device to come online (${Date.now() - startTime}ms elapsed)`);
+			}
+			try {
+				//ensure the ECP webserver is responsive
+				await rokuDeploy.getDeviceInfo({ device: rokuDeployDevice, timeout: intervalMs });
+				//ensure the plugin_install webserver is responsive
+				await rokuDeploy.listSideloadedPlugins({ device: rokuDeployDevice, password: password, timeout: intervalMs });
+
+				//some devices are not fully ready to speak yet, so if this was the result of a long wait,
+				//wait a little bit longer
+				if (count > 1) {
+					console.log('[device-health] device is online, waiting a few more seconds to ensure it is fully ready...');
+					await utils.sleep(5_000);
+					console.log(`[device-health] device is online after ${Date.now() - startTime}ms`);
+				}
+				return;
+			} catch (e) {
+				lastError = e as Error;
+				await utils.sleep(intervalMs);
+			}
+		}
+		throw new Error(`Device did not come online within ${timeoutMs}ms. Last error: ${lastError?.message}`);
+	}
+
 	// roku-deploy sends the key text as-is (no retry, uri-encoding handled internally); RTA just retries here
 	private async sendKeyEventToRokuDeploy(rokuDeployMethod: 'keyPress' | 'keyDown' | 'keyUp', key: string, options: HttpRequestOptions = {}): Promise<EcpResult> {
 		let retryCount = options.retryCount;

--- a/src/test/testHelpers.spec.ts
+++ b/src/test/testHelpers.spec.ts
@@ -1,5 +1,4 @@
 import * as fsExtra from 'fs-extra';
-import { rokuDeploy } from 'roku-deploy';
 import type { EcpResponse } from '../RokuDevice';
 import { parseEcpResponse } from '../EcpXml';
 import * as path from 'path';
@@ -68,55 +67,6 @@ function getHealthCheckDevice() {
 }
 
 /**
- * Wait for the device to be reachable and responsive by polling both ECP (device-info) and the
- * installer web server (the same `plugin_install` endpoint sideload/publish use) until both respond.
- *
- * ECP alone isn't enough: it can come back before the installer server has finished settling, which
- * shows up as flaky sideload failures even though an ECP check had just reported the device online.
- *
- * @param graceMs how long to wait before the first poll. Use a non-zero value after issuing something
- *   that reboots the device, so we don't immediately see the still-alive pre-reboot device.
- */
-export async function waitForDeviceOnline(timeoutMs = 120_000, intervalMs = 3000, graceMs = 0): Promise<void> {
-	const startTime = Date.now();
-	const deadline = startTime + timeoutMs;
-	const healthDevice = getHealthCheckDevice();
-	const rokuDeployDevice = healthDevice.getRokuDeployDevice();
-	const password = healthDevice.getCurrentDeviceConfig().password;
-
-	if (graceMs > 0) {
-		await utils.sleep(graceMs);
-	}
-
-	let lastError: Error | undefined;
-	let count = 0;
-	while (Date.now() < deadline) {
-		if (count++ > 0) {
-			console.log(`[device-health] waiting for device to come online (${Date.now() - startTime}ms elapsed)`);
-		}
-		try {
-			//ensure the ECP webserver is responsive
-			await rokuDeploy.getDeviceInfo({ device: rokuDeployDevice, timeout: intervalMs });
-			//ensure the plugin_install webserver is responsive
-			await rokuDeploy.listSideloadedPlugins({ device: rokuDeployDevice, password: password, timeout: intervalMs });
-
-			//some devices are not fully ready to speak yet, so if this was the result of a long wait,
-			//wait a little bit longer
-			if (count > 1) {
-				console.log('[device-health] device is online, waiting a few more seconds to ensure it is fully ready...');
-				await utils.sleep(5_000);
-				console.log(`[device-health] device is online after ${Date.now() - startTime}ms`);
-			}
-			return;
-		} catch (e) {
-			lastError = e as Error;
-			await utils.sleep(intervalMs);
-		}
-	}
-	throw new Error(`Device did not come online within ${timeoutMs}ms. Last error: ${lastError?.message}`);
-}
-
-/**
  * Send a couple of Home presses to clear any foreground app/screensaver, so the next test starts from
  * a known state instead of whatever the previous test left on screen.
  */
@@ -134,7 +84,7 @@ export async function pressHomeButton(): Promise<void> {
  * previous suite left running. Call this from a `before` hook, ahead of any deploy/launch.
  */
 export async function ensureDeviceIsReady(): Promise<void> {
-	await waitForDeviceOnline(90_000, 2000, 0);
+	await getHealthCheckDevice().waitForDeviceOnline(90_000, 2000, 0);
 	await pressHomeButton();
 }
 
@@ -148,7 +98,7 @@ export async function ensureDeviceIsReady(): Promise<void> {
  * under them by a per-test Home press.
  */
 export async function ensureDeviceIsStillResponsive(): Promise<void> {
-	await waitForDeviceOnline(90_000, 2000, 0);
+	await getHealthCheckDevice().waitForDeviceOnline(90_000, 2000, 0);
 }
 
 /**


### PR DESCRIPTION
Moving waitForDeviceOnline method to RokuDevice to allow others using RTA to be able to use in their own tests