### PR TITLE
chore: Security enhancements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3941,9 +3941,9 @@
             "license": "MIT"
         },
         "node_modules/js-yaml": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-            "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+            "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
             "dev": true,
             "funding": [
                 {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "overrides": {
         "serialize-javascript": "^7.0.5",
         "brace-expansion": "^2.1.4",
-        "js-yaml": "^4.3.1",
+        "js-yaml": "^4.3.2",
         "qs": "^6.16.0",
         "uuid": "^11.1.1",
         "browserslist": "^4.28.8"


### PR DESCRIPTION
Clears GHSA-2883-xcg3-v3hh (js-yaml, high), the only advisory failing the audit gate.

`npm audit --omit=dev`: **0 vulnerabilities**. Full `npm audit` is also at 0 after this change.

## Ships to consumers
Nothing. The only change is dev-scoped.

## Lockfile only (dev deps)
| Override | Before | After | Reached via |
|---|---|---|---|
| `js-yaml` | `^4.3.1` | `^4.3.2` | `eslint`, `mocha`, `nyc` |

## Notes for the reviewer
- The previous `^4.3.1` pin landed exactly inside the new advisory's range (`4.0.0 - 4.3.1`), so the gate went red without anything in this repo changing. 4.3.2 is a patch bump.

## Verification
`npm run preversion` (build + lint + test + validate-client + audit) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)